### PR TITLE
Change base image from alpine to distroless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go install \
   ./...
 
 ############# cloud-provider-gcp #############
-FROM alpine:3.15.4 AS cloud-provider-gcp
+FROM gcr.io/distroless/static-debian11:nonroot AS cloud-provider-gcp
 
 COPY --from=builder /go/bin/gcp-cloud-controller-manager /gcp-cloud-controller-manager
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes the base image for `cloud-provider-gcp` from `alpine` to [distroless](https://github.com/GoogleContainerTools/distroless). The process will now use a non root user for its execution. This will reduce the attack surface of the images.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The `cloud-provider-gcp` container now uses `distroless` instead of `alpine` as a base image.
```
