### PR TITLE
switch GCR -> Artifact-Registry

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -1,22 +1,17 @@
 cloud-provider-gcp:
-  template: 'default'
   base_definition:
-    repo: ~
     traits:
       version:
         preprocess: 'inject-commit-hash'
       publish:
         dockerimages:
           cloud-provider-gcp:
-            registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/kubernetes/cloud-provider-gcp'
             dockerfile: 'Dockerfile'
             target: cloud-provider-gcp
-    steps: ~
   jobs:
     head-update:
       traits:
-        component_descriptor: ~
         draft_release: ~
     pull-request:
       traits:

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -3,28 +3,36 @@ cloud-provider-gcp:
     traits:
       version:
         preprocess: 'inject-commit-hash'
+      component_descriptor:
+        ocm_repository: europe-docker.pkg.dev/gardener-project/snapshots
       publish:
         dockerimages:
           cloud-provider-gcp:
-            image: 'eu.gcr.io/gardener-project/kubernetes/cloud-provider-gcp'
+            image: europe-docker.pkg.dev/gardener-project/snapshots/kubernetes/cloud-provider-gcp
             dockerfile: 'Dockerfile'
             target: cloud-provider-gcp
   jobs:
     head-update:
       traits:
         draft_release: ~
+        component_descriptor:
+          ocm_repository: europe-docker.pkg.dev/gardener-project/snapshots
     pull-request:
       traits:
         pull-request: ~
-        component_descriptor: ~
+        component_descriptor:
+          ocm_repository_mappings:
+            - repository: europe-docker.pkg.dev/gardener-project/releases
     release:
       traits:
         version:
           preprocess: 'finalize'
         release:
           nextversion: 'bump_minor'
-        component_descriptor: ~
+        component_descriptor:
+          ocm_repository: europe-docker.pkg.dev/gardener-project/releases
         publish:
           dockerimages:
             cloud-provider-gcp:
               tag_as_latest: true
+              image: europe-docker.pkg.dev/gardener-project/releases/kubernetes/cloud-provider-gcp


### PR DESCRIPTION
GCR has been deprecated [0] in favour of Artifact-Registry.

Thus, change push-targets for OCI-Images:

- europe-docker.pkg.dev/gardener-project/snapshots for snapshots
- europe-docker.pkg.dev/gardener-project/releases for releases
- europe-docker.pkg.dev/gardener-project/public for combined view of snapshots + releases

[0]
https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr


**Release note**:

```breaking operator
Change OCI Image Registry from GCR (`eu.gcr.io/gardener-project`) to Artifact-Registry (`europe-docker.pkg.dev/gardener-project/releases`). Users should update their references.

```
